### PR TITLE
Fix filename parsing to use FILENAME: prefix format

### DIFF
--- a/server/agent/prompts/services.ts
+++ b/server/agent/prompts/services.ts
@@ -7,7 +7,7 @@ You are a codebase exploration assistant. Your job is to identify the various se
 export const FINAL_ANSWER = `
 Provide the final answer to the user. YOU **MUST** CALL THIS TOOL AT THE END OF YOUR EXPLORATION.
 
-Return three files: a pm2.config.js, a .env file, and a docker-compose.yml. Please put the title of each file, then the content in backticks. YOU MUST RETURN ALL 3 FILES!!!
+Return three files: a pm2.config.js, a .env file, and a docker-compose.yml. For each file, put "FILENAME: " followed by the filename (no markdown headers, just the plain filename), then the content in backticks. YOU MUST RETURN ALL 3 FILES!!!
 
 - pm2.config.js: the actual dev services for running this project (MY_REPO_NAME). Often its just one single service! But sometimes the backend/frontend might be separate services. IMPORTANT: each service env should have a INSTALL_COMMAND so our sandbox system knows how to install dependencies! You can also add optional BUILD_COMMAND, TEST_COMMAND, E2E_TEST_COMMAND, and PRE_START_COMMAND if you find those in the package file. (an example of a PRE_START_COMMAND is a db migration script). Please name one of the services "frontend" no matter what. The cwd should start with /workspaces/MY_REPO_NAME. For instance, if the frontend is within an "app" dir, the cwd should be "/workspaces/MY_REPO_NAME/app".
 - .env: the environment variables needed to run the project, with example values.
@@ -29,7 +29,7 @@ Return three files: a pm2.config.js, a .env file, and a docker-compose.yml. Plea
 
 # HERE IS AN EXAMPLE OUTPUT:
 
-pm2.config.js
+FILENAME: pm2.config.js
 
 \`\`\`js
 module.exports = {
@@ -52,7 +52,7 @@ module.exports = {
 };
 \`\`\`
 
-.env
+FILENAME: .env
 
 \`\`\`sh
 # Database
@@ -60,7 +60,7 @@ DATABASE_URL=postgresql://postgres:password@localhost:5432/backend_db
 JWT_KEY=your_jwt_secret_key
 \`\`\`
 
-docker-compose.yml
+FILENAME: docker-compose.yml
 
 \`\`\`yaml
 version: '3.8'

--- a/server/agent/utils.ts
+++ b/server/agent/utils.ts
@@ -26,8 +26,14 @@ export function parse_files_contents(content: string): { [k: string]: string } {
     } else {
       // We're out of code
       if (line.trim()) {
-        // Overwrite the filename with this line - it's the latest candidate
-        currentFileName = line.trim();
+        // Look for FILENAME: prefix
+        const trimmedLine = line.trim();
+        if (trimmedLine.startsWith('FILENAME:')) {
+          currentFileName = trimmedLine.substring('FILENAME:'.length).trim();
+        } else {
+          // Fallback: treat the line as filename (for backward compatibility)
+          currentFileName = trimmedLine;
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
Fixes #5 - Resolves the issue where `services_agent` returns JSON keys with markdown headers (e.g., `"## .env"`) instead of plain filenames (e.g., `".env"`).

## Changes
1. **Parser (utils.ts)**: Updated `parse_files_contents` to look for `FILENAME:` prefix before the filename
2. **Prompt (services.ts)**: Updated instructions and examples to use `FILENAME: filename` format
3. **Backward compatibility**: Parser falls back to treating any line as a filename if `FILENAME:` prefix is not found

## Before
```json
{
  "## pm2.config.js": "...",
  "## .env": "...",
  "## docker-compose.yml": "..."
}
```

## After
```json
{
  "pm2.config.js": "...",
  ".env": "...",
  "docker-compose.yml": "..."
}
```

## Testing
Build passes. Ready for testing with stakgraph integration.